### PR TITLE
chore: add namespce to deploy.yaml

### DIFF
--- a/controller-v1.12.1/deploy.yaml
+++ b/controller-v1.12.1/deploy.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
 ---
 # Source: ingress-nginx/templates/controller-serviceaccount.yaml
 apiVersion: v1


### PR DESCRIPTION
안녕하세요, 카카오 클라우드 담당자 여러분.

먼저, ingress-nginx-controller의 최신 버전(1.12.1)을 새롭게 제공해주신 점 진심으로 감사드립니다. 기존에는 1.3.1 버전만 제공되어 아쉬움이 있었는데, 최신 버전의 지원이 매우 반가웠습니다.

다만, 공식 튜토리얼을 따라 설치를 진행하는 과정에서 namespace가 자동으로 생성되지 않아 설치가 실패하는 이슈가 있었습니다. 이를 처음 접하는 사용자 입장에서는 원인을 파악하기 어려울 수 있기에, 본 PR에서는 해당 namespace가 함께 생성되도록 수정하였습니다.

작은 부분이지만 튜토리얼을 보다 원활히 따라갈 수 있도록 도움이 되었으면 합니다.
검토 부탁드립니다. 감사합니다! 🙇‍♂️